### PR TITLE
Give call access to branch and method

### DIFF
--- a/sha2.lua
+++ b/sha2.lua
@@ -5653,6 +5653,9 @@ local sha = {
    -- BLAKE3 hash function
    blake3            = blake3,             -- BLAKE3    (message, key, digest_size_in_bytes)
    blake3_derive_key = blake3_derive_key,  -- BLAKE3_KDF(key_material, context_string, derived_key_size_in_bytes)
+   -- Let user detect which implementation is being used
+   branch     = branch,
+   method     = method,
 }
 
 


### PR DESCRIPTION
It seems reasonable that the caller should be able to detect the code path and method it is using; e.g. for recording against benchmarks